### PR TITLE
echo and path

### DIFF
--- a/oraclefetch.sh
+++ b/oraclefetch.sh
@@ -13,6 +13,7 @@ for i in $(seq 0 $(( $len - 1 )))
 do
 if [ $sub = ${pubsarray[$i]} ]
 then
-komodo-cli -ac_name=STAKEDB1 oraclessamples $orclid ${batonarray[$i]} 1 | jq -r '.samples[0][0]' | jq . > $HOME/StakedNotary/assetchains.json
+komodo-cli -ac_name=STAKEDB1 oraclessamples $orclid ${batonarray[$i]} 1 | jq -r '.samples[0][0]' | jq . > $HOME/.komodo/assetchains.json
 fi
 done
+echo $HOME/.komodo/assetchains.json


### PR DESCRIPTION
change assetchains.json path to a folder outside Notary repo, and with other configs
add echo to end of script to allow `ac_json=$(cat $(./oraclefetch.sh))` as a means to populate variable directly from oracle (no git, no http)