### PR TITLE
Update stats.sh

### DIFF
--- a/stats.sh
+++ b/stats.sh
@@ -92,7 +92,12 @@ outputstats ()
             ntrzd=$(jq --arg address "${kmdntrzaddr}" --arg timefilter ${timefilter2} '[.[] | select(.time>=($timefilter|tonumber) and .address==$address and .category=="send")] | length' <<<"${txinfo}")
             totalntrzd=$(( totalntrzd + ntrzd ))
             # this now shows the % of possible notarizations in the range of blocks scanned, was innaccurate before as the entire chain is not scanned. 
-            pct=$(echo "${ntrzd}/(${txscanamount}/${freq})*100" | bc -l)
+			if [[ "${coin}" = "KMD" ]]; then
+				printpct=""
+			else
+				pct=$(echo "${ntrzd}/(${txscanamount}/${freq})*100" | bc -l)
+				printpct="$(printf "%2.1f" $(echo ${pct}))%"
+			fi
             printf "${format}" "${coin}" \
                 "$(printf "%12.4f" $(jq .balance <<<"${info}"))" \
                 "$(${cli} getwalletinfo | jq .txcount)" \
@@ -100,7 +105,7 @@ outputstats ()
                 "$(jq --arg amt "${utxoamt}" '[.[] | select(.amount<($amt|tonumber))] | length' <<<"${unspents}")" \
                 "${ntrzd}" \
                 "${blocks}" \
-                "$(printf "%2.1f" $(echo ${pct}))%" \
+                "${printpct}" \
                 "$(timeSince ${lastntrztime})" \
                 "$(jq .connections <<<"${info}")" 
                 echo ""


### PR DESCRIPTION
fixes `(standard_in) 1: syntax error` because KMD has no `feq` value